### PR TITLE
Market pallet: use separate rc block type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,8 +162,8 @@ ismp-testsuite = { git="https://github.com/polytope-labs/hyperbridge.git", branc
 
 # Local
 region-primitives = { path = "./primitives/region", default-features = false }
-nonfungible-primitives= { path = "./primitives/nonfungible", default-features = false }
+nonfungible-primitives = { path = "./primitives/nonfungible", default-features = false }
 regionx-primitives = { path = "./runtime/primitives", default-features = false }
 regionx-runtime = { path = "./runtime/regionx", default-features = false }
-pallet-regions = { path = "./pallets/regions", default-features = false }
 pallet-market = { path = "./pallets/market", default-features = false }
+pallet-regions = { path = "./pallets/regions", default-features = false }

--- a/pallets/market/Cargo.toml
+++ b/pallets/market/Cargo.toml
@@ -4,8 +4,6 @@ authors = ["Anonymous"]
 description = "Pallet containing the Coretime marketplace logic"
 version = "0.1.0"
 license = "GPLv3"
-homepage = "https://substrate.io"
-repository = "https://github.com/paritytech/substrate/"
 edition = "2021"
 
 [package.metadata.docs.rs]

--- a/pallets/market/src/mock.rs
+++ b/pallets/market/src/mock.rs
@@ -19,7 +19,6 @@ use frame_support::{
 	parameter_types,
 	traits::{nonfungible::Mutate, Everything},
 };
-use frame_system as system;
 use ismp::{
 	consensus::StateMachineId,
 	dispatcher::{DispatchRequest, FeeMetadata, IsmpDispatcher},
@@ -54,7 +53,7 @@ parameter_types! {
 	pub const SS58Prefix: u8 = 42;
 }
 
-impl system::Config for Test {
+impl frame_system::Config for Test {
 	type BaseCallFilter = Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
@@ -139,7 +138,6 @@ parameter_types! {
 
 impl pallet_regions::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
-	type Balance = u64;
 	type Currency = Balances;
 	type CoretimeChain = CoretimeChain;
 	type IsmpDispatcher = MockDispatcher<Self>;
@@ -175,10 +173,9 @@ impl crate::RegionFactory<Test> for RegionFactory {
 
 impl crate::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
-	type Balance = u64;
 	type Currency = Balances;
 	type Regions = Regions;
-	type RelayChainBlockNumber = RelayBlockNumberProvider;
+	type RCBlockNumberProvider = RelayBlockNumberProvider;
 	type TimeslicePeriod = ConstU64<80>;
 	type WeightInfo = ();
 	#[cfg(feature = "runtime-benchmarks")]

--- a/pallets/regions/Cargo.toml
+++ b/pallets/regions/Cargo.toml
@@ -4,8 +4,6 @@ authors = ["Anonymous"]
 description = "Pallet responsible for handling Coretime regions"
 version = "0.1.0"
 license = "GPLv3"
-homepage = "https://substrate.io"
-repository = "https://github.com/paritytech/substrate/"
 edition = "2021"
 
 [package.metadata.docs.rs]

--- a/pallets/regions/src/lib.rs
+++ b/pallets/regions/src/lib.rs
@@ -66,13 +66,7 @@ pub const PALLET_ID: ModuleId = ModuleId::Pallet(PalletId(*b"regionsp"));
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
-	use frame_support::{
-		pallet_prelude::*,
-		traits::{
-			fungible::{Inspect, Mutate},
-			tokens::Balance,
-		},
-	};
+	use frame_support::{pallet_prelude::*, traits::fungible::Mutate};
 	use frame_system::pallet_prelude::*;
 
 	/// The module configuration trait.
@@ -80,11 +74,6 @@ pub mod pallet {
 	pub trait Config: frame_system::Config {
 		/// The overarching event type.
 		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
-
-		/// Native balance
-		type Balance: Balance
-			+ Into<<Self::Currency as Inspect<Self::AccountId>>::Balance>
-			+ From<u32>;
 
 		/// Currency implementation
 		//
@@ -95,7 +84,7 @@ pub mod pallet {
 		type CoretimeChain: Get<StateMachine>;
 
 		/// The ISMP dispatcher.
-		type IsmpDispatcher: IsmpDispatcher<Account = Self::AccountId, Balance = <Self as Config>::Balance>
+		type IsmpDispatcher: IsmpDispatcher<Account = Self::AccountId, Balance = BalanceOf<Self>>
 			+ Default;
 
 		/// Used for getting the height of the Coretime chain.

--- a/pallets/regions/src/mock.rs
+++ b/pallets/regions/src/mock.rs
@@ -15,7 +15,6 @@
 
 use crate::{ismp_mock::MockDispatcher, StateMachineHeightProvider};
 use frame_support::{pallet_prelude::*, parameter_types, traits::Everything};
-use frame_system as system;
 use ismp::{consensus::StateMachineId, host::StateMachine};
 use sp_core::{ConstU64, H256};
 use sp_runtime::{
@@ -40,7 +39,7 @@ parameter_types! {
 	pub const SS58Prefix: u8 = 42;
 }
 
-impl system::Config for Test {
+impl frame_system::Config for Test {
 	type BaseCallFilter = Everything;
 	type BlockWeights = ();
 	type BlockLength = ();
@@ -97,7 +96,6 @@ impl StateMachineHeightProvider for MockStateMachineHeightProvider {
 
 impl crate::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
-	type Balance = u64;
 	type Currency = Balances;
 	type CoretimeChain = CoretimeChain;
 	type IsmpDispatcher = MockDispatcher<Self>;

--- a/runtime/regionx/src/lib.rs
+++ b/runtime/regionx/src/lib.rs
@@ -616,7 +616,6 @@ parameter_types! {
 
 impl pallet_regions::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type Balance = Balance;
 	type Currency = Balances;
 	type CoretimeChain = CoretimeChain;
 	type IsmpDispatcher = Ismp;
@@ -755,7 +754,6 @@ impl pallet_treasury::Config for Runtime {
 
 impl pallet_market::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type Balance = Balance;
 	// To make benchmarking easier we use the native currency for coretime purchases.
 	//
 	// In production we use the relay chain asset.
@@ -766,7 +764,7 @@ impl pallet_market::Config for Runtime {
 	#[cfg(not(feature = "runtime-benchmarks"))]
 	type Currency = RelaychainCurrency;
 	type Regions = Regions;
-	type RelayChainBlockNumber = RelaychainDataProvider<Self>;
+	type RCBlockNumberProvider = RelaychainDataProvider<Self>;
 	type TimeslicePeriod = ConstU32<80>;
 	type WeightInfo = ();
 	#[cfg(feature = "runtime-benchmarks")]


### PR DESCRIPTION
In the pallet we assumed that the rc has the same block number type as the RegionX parachain.
With this PR we remove that assumption.

This PR also contains some other small fixes.