### PR TITLE
Only expired orders can be cancelled

### DIFF
--- a/pallets/orders/src/lib.rs
+++ b/pallets/orders/src/lib.rs
@@ -187,6 +187,8 @@ pub mod pallet {
 		/// If the region requirements on which the order was based are for an expired region,
 		/// anyone can cancel the order.
 		///
+		/// Only expired orders can be cancelled.
+		///
 		/// ## Arguments:
 		/// - `order_id`: The order the caller wants to cancel.
 		#[pallet::call_index(1)]
@@ -195,10 +197,7 @@ pub mod pallet {
 			let who = ensure_signed(origin)?;
 
 			let order = Orders::<T>::get(order_id).ok_or(Error::<T>::InvalidOrderId)?;
-			ensure!(
-				order.creator == who || order.requirements.end < Self::current_timeslice(),
-				Error::<T>::NotAllowed
-			);
+			ensure!(order.requirements.end < Self::current_timeslice(), Error::<T>::NotAllowed);
 
 			Orders::<T>::remove(order_id);
 


### PR DESCRIPTION
If we allow order creators to cancel an order at any time, we risk them manipulating someone into purchasing Coretime in the bulk sale, expecting to sell it to the order. However, by the time they purchase the Coretime and want to sell it, the order could be canceled. This would create a false demand signal.