### PR TITLE
Async backing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9567,6 +9567,7 @@ dependencies = [
  "cumulus-pallet-session-benchmarking",
  "cumulus-pallet-xcm",
  "cumulus-pallet-xcmp-queue",
+ "cumulus-primitives-aura",
  "cumulus-primitives-core",
  "cumulus-primitives-timestamp",
  "cumulus-primitives-utility",

--- a/node/src/runtime_api.rs
+++ b/node/src/runtime_api.rs
@@ -37,6 +37,7 @@ pub trait BaseHostRuntimeApis:
 	+ CollectCollationInfo<Block>
 	+ TransactionPaymentRuntimeApi<Block, Balance>
 	+ ismp_parachain_runtime_api::IsmpParachainApi<Block>
+	+ cumulus_primitives_aura::AuraUnincludedSegmentApi<Block>
 	+ pallet_ismp_runtime_api::IsmpRuntimeApi<Block, H256>
 {
 }
@@ -53,6 +54,7 @@ impl<Api> BaseHostRuntimeApis for Api where
 		+ CollectCollationInfo<Block>
 		+ TransactionPaymentRuntimeApi<Block, Balance>
 		+ ismp_parachain_runtime_api::IsmpParachainApi<Block>
+		+ cumulus_primitives_aura::AuraUnincludedSegmentApi<Block>
 		+ pallet_ismp_runtime_api::IsmpRuntimeApi<Block, H256>
 {
 }

--- a/runtime/regionx-rococo/Cargo.toml
+++ b/runtime/regionx-rococo/Cargo.toml
@@ -99,6 +99,7 @@ cumulus-pallet-parachain-system = { workspace = true }
 cumulus-pallet-session-benchmarking = { workspace = true }
 cumulus-pallet-xcm = { workspace = true }
 cumulus-pallet-xcmp-queue = { workspace = true }
+cumulus-primitives-aura = { workspace = true }
 cumulus-primitives-core = { workspace = true }
 cumulus-primitives-utility = { workspace = true }
 cumulus-primitives-timestamp = { workspace = true }
@@ -116,6 +117,7 @@ std = [
 	"cumulus-pallet-session-benchmarking/std",
 	"cumulus-pallet-xcm/std",
 	"cumulus-pallet-xcmp-queue/std",
+	"cumulus-primitives-aura/std",
 	"cumulus-primitives-core/std",
 	"cumulus-primitives-utility/std",
 	"cumulus-primitives-timestamp/std",


### PR DESCRIPTION
We still do not have async backing enabled. However, this PR includes the first two parts of the guide to update the runtime and node to potentially support async backing. [Guide Link](https://wiki.polkadot.network/docs/maintain-guides-async-backing)

Previously, we encountered an error in the logs when deploying the parachain to a relay chain that supports async backing. This PR fixes that by updating the runtime and node of the parachain.

The error we were receiving: https://forum.polkadot.network/t/async-backing-development-updates/6176/7