### PR TITLE
Region pallet: remove automatic request

### DIFF
--- a/e2e_tests/xc-transfer/region-transfer.ts
+++ b/e2e_tests/xc-transfer/region-transfer.ts
@@ -106,6 +106,9 @@ async function run(_nodeName: any, networkInfo: any, _jsArgs: any) {
 
   await sleep(5000);
 
+  const requestRecord = regionXApi.tx.regions.requestRegionRecord(regionId);
+  await submitExtrinsic(alice, requestRecord, {});
+
   let regions = await regionXApi.query.regions.regions.entries();
   assert.equal(regions.length, 1);
   assert.deepStrictEqual(regions[0][0].toHuman(), [regionId]);

--- a/pallets/regions/src/benchmarking.rs
+++ b/pallets/regions/src/benchmarking.rs
@@ -61,11 +61,7 @@ mod benchmarks {
 		let caller: T::AccountId = whitelisted_caller();
 		let region_id = RegionId { begin: 112830, core: 72, mask: CoreMask::complete() };
 
-		// Create a region with an unavailable record, allowing us to re-request the record.
-		crate::Regions::<T>::insert(
-			region_id,
-			Region { owner: caller.clone(), record: Record::Unavailable, locked: false },
-		);
+		assert_ok!(crate::Pallet::<T>::mint_into(&region_id.into(), &caller));
 
 		#[extrinsic_call]
 		_(RawOrigin::Signed(caller.clone()), region_id);

--- a/pallets/regions/src/lib.rs
+++ b/pallets/regions/src/lib.rs
@@ -252,10 +252,7 @@ pub mod pallet {
 				dest: T::CoretimeChain::get(),
 				from: PALLET_ID.to_bytes(),
 				keys: vec![key],
-				// We require data following the cross-chain transfer, which will be available in
-				// the subsequent block. However, if the core time chain has a block production rate
-				// of 6 seconds, we will only have the commitment from the block after the next one.
-				height: coretime_chain_height.saturating_add(2),
+				height: coretime_chain_height,
 				timeout: T::Timeout::get(),
 			};
 


### PR DESCRIPTION
From a UX perspective, it is more practical to make an ISMP request when the user demands it, instead of making one immediately when the region is minted.

Also, the height at which we were requesting the data from the Coretime chain was causing the parachain to break, as it was attempting to access a block that was not yet available. This PR fixes that issue.