### PR TITLE
Patch release

### DIFF
--- a/runtime/cocos/src/lib.rs
+++ b/runtime/cocos/src/lib.rs
@@ -188,7 +188,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("regionx-parachain"),
 	impl_name: create_runtime_str!("regionx-parachain"),
 	authoring_version: 1,
-	spec_version: 1,
+	spec_version: 1_000_001,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
A new patch release which includes this fix: https://github.com/RegionX-Labs/RegionX-Node/pull/188

Also, with this PR we update the versioning notation to use semantic versioning.