### PR TITLE
Order accounts

### DIFF
--- a/pallets/orders/src/lib.rs
+++ b/pallets/orders/src/lib.rs
@@ -125,15 +125,6 @@ pub mod pallet {
 		ValueQuery,
 	>;
 
-	/// The total amount that was contributed to an order.
-	///
-	/// The sum of contributions for a specific order from the `Contributions` map should be equal
-	/// to the total contribution stored here.
-	#[pallet::storage]
-	#[pallet::getter(fn total_contributions)]
-	pub type TotalContributions<T: Config> =
-		StorageMap<_, Blake2_128Concat, OrderId, BalanceOf<T>, ValueQuery>;
-
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config> {
@@ -240,10 +231,6 @@ pub mod pallet {
 			contribution = contribution.saturating_add(amount);
 			Contributions::<T>::insert(order_id, who.clone(), contribution);
 
-			let mut total_contributions = TotalContributions::<T>::get(order_id);
-			total_contributions = total_contributions.saturating_add(amount);
-			TotalContributions::<T>::insert(order_id, total_contributions);
-
 			Self::deposit_event(Event::Contributed { order_id, who, amount });
 
 			Ok(())
@@ -272,10 +259,6 @@ pub mod pallet {
 				ExistenceRequirement::AllowDeath,
 			)?;
 			Contributions::<T>::remove(order_id, who.clone());
-
-			let mut total_contributions = TotalContributions::<T>::get(order_id);
-			total_contributions = total_contributions.saturating_sub(amount);
-			TotalContributions::<T>::insert(order_id, total_contributions);
 
 			Self::deposit_event(Event::ContributionRemoved { who, order_id, amount });
 

--- a/pallets/orders/src/mock.rs
+++ b/pallets/orders/src/mock.rs
@@ -130,7 +130,7 @@ impl BlockNumberProvider for RelayBlockNumberProvider {
 pub struct DummyOrderToAccountId;
 impl Convert<OrderId, AccountId> for DummyOrderToAccountId {
 	fn convert(o: OrderId) -> AccountId {
-		AccountId::new([o as u8; 32])
+		AccountId::new([255 - o as u8; 32])
 	}
 }
 

--- a/pallets/orders/src/mock.rs
+++ b/pallets/orders/src/mock.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with RegionX.  If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{FeeHandler, ParaId};
+use crate::{FeeHandler, OrderId, ParaId};
 use frame_support::{
 	pallet_prelude::*,
 	parameter_types,
@@ -21,7 +21,7 @@ use frame_support::{
 };
 use sp_core::{ConstU64, H256};
 use sp_runtime::{
-	traits::{BlakeTwo256, BlockNumberProvider, IdentityLookup},
+	traits::{BlakeTwo256, BlockNumberProvider, Convert, IdentityLookup},
 	AccountId32, BuildStorage,
 };
 use xcm::opaque::lts::NetworkId;
@@ -127,6 +127,13 @@ impl BlockNumberProvider for RelayBlockNumberProvider {
 	}
 }
 
+pub struct DummyOrderToAccountId;
+impl Convert<OrderId, AccountId> for DummyOrderToAccountId {
+	fn convert(o: OrderId) -> AccountId {
+		AccountId::new([o as u8; 32])
+	}
+}
+
 impl crate::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type Currency = Balances;
@@ -134,6 +141,7 @@ impl crate::Config for Test {
 	type OrderCreationCost = ConstU64<100>;
 	type MinimumContribution = ConstU64<50>;
 	type RCBlockNumberProvider = RelayBlockNumberProvider;
+	type OrderToAccountId = DummyOrderToAccountId;
 	type TimeslicePeriod = ConstU64<80>;
 	type OrderCreationFeeHandler = OrderCreationFeeHandler;
 	type WeightInfo = ();

--- a/pallets/orders/src/mock.rs
+++ b/pallets/orders/src/mock.rs
@@ -20,6 +20,7 @@ use frame_support::{
 	traits::{fungible::Mutate, tokens::Preservation, Everything},
 };
 use sp_core::{ConstU64, H256};
+use sp_io::hashing::blake2_256;
 use sp_runtime::{
 	traits::{BlakeTwo256, BlockNumberProvider, Convert, IdentityLookup},
 	AccountId32, BuildStorage,
@@ -127,10 +128,10 @@ impl BlockNumberProvider for RelayBlockNumberProvider {
 	}
 }
 
-pub struct DummyOrderToAccountId;
-impl Convert<OrderId, AccountId> for DummyOrderToAccountId {
-	fn convert(o: OrderId) -> AccountId {
-		AccountId::new([255 - o as u8; 32])
+pub struct OrderToAccountId;
+impl Convert<OrderId, AccountId> for OrderToAccountId {
+	fn convert(order: OrderId) -> AccountId {
+		("order", order).using_encoded(blake2_256).into()
 	}
 }
 
@@ -141,7 +142,7 @@ impl crate::Config for Test {
 	type OrderCreationCost = ConstU64<100>;
 	type MinimumContribution = ConstU64<50>;
 	type RCBlockNumberProvider = RelayBlockNumberProvider;
-	type OrderToAccountId = DummyOrderToAccountId;
+	type OrderToAccountId = OrderToAccountId;
 	type TimeslicePeriod = ConstU64<80>;
 	type OrderCreationFeeHandler = OrderCreationFeeHandler;
 	type WeightInfo = ();

--- a/pallets/orders/src/tests.rs
+++ b/pallets/orders/src/tests.rs
@@ -149,7 +149,6 @@ fn contribute_works() {
 		// Check storage items
 		assert_eq!(Orders::contributions(0, CHARLIE), 500);
 		assert_eq!(Orders::contributions(0, BOB), 100);
-		assert_eq!(Orders::total_contributions(0), 600);
 
 		assert_eq!(Balances::free_balance(CHARLIE), 500);
 		assert_eq!(Balances::free_balance(BOB), 900);
@@ -160,7 +159,6 @@ fn contribute_works() {
 		assert_ok!(Orders::contribute(RuntimeOrigin::signed(CHARLIE), 0, 300));
 		assert_eq!(Orders::contributions(0, CHARLIE), 800);
 		assert_eq!(Orders::contributions(0, BOB), 100);
-		assert_eq!(Orders::total_contributions(0), 900);
 
 		// Cannot contribute to an expired order
 		let timeslice: u64 = <Test as crate::Config>::TimeslicePeriod::get();
@@ -173,7 +171,6 @@ fn contribute_works() {
 
 		assert_eq!(Orders::contributions(0, CHARLIE), 800);
 		assert_eq!(Orders::contributions(0, BOB), 100);
-		assert_eq!(Orders::total_contributions(0), 900);
 	});
 }
 
@@ -198,7 +195,6 @@ fn remove_contribution_works() {
 		assert_ok!(Orders::contribute(RuntimeOrigin::signed(BOB), 0, 200));
 
 		assert_eq!(Balances::free_balance(CHARLIE), 500);
-		assert_eq!(Orders::total_contributions(0), 700);
 		let order_account = DummyOrderToAccountId::convert(0);
 		assert_eq!(Balances::free_balance(order_account.clone()), 700);
 
@@ -212,7 +208,6 @@ fn remove_contribution_works() {
 
 		// Check storage items
 		assert_eq!(Balances::free_balance(CHARLIE), 1000);
-		assert_eq!(Orders::total_contributions(0), 200);
 		assert_eq!(Balances::free_balance(order_account), 200);
 
 		// Check the events

--- a/pallets/orders/src/tests.rs
+++ b/pallets/orders/src/tests.rs
@@ -152,7 +152,7 @@ fn contribute_works() {
 
 		assert_eq!(Balances::free_balance(CHARLIE), 500);
 		assert_eq!(Balances::free_balance(BOB), 900);
-		let order_account = DummyOrderToAccountId::convert(0);
+		let order_account = OrderToAccountId::convert(0);
 		assert_eq!(Balances::free_balance(order_account), 600);
 
 		// Additional contributions work:
@@ -195,7 +195,7 @@ fn remove_contribution_works() {
 		assert_ok!(Orders::contribute(RuntimeOrigin::signed(BOB), 0, 200));
 
 		assert_eq!(Balances::free_balance(CHARLIE), 500);
-		let order_account = DummyOrderToAccountId::convert(0);
+		let order_account = OrderToAccountId::convert(0);
 		assert_eq!(Balances::free_balance(order_account.clone()), 700);
 
 		// Cancel the expired order:

--- a/pallets/orders/src/tests.rs
+++ b/pallets/orders/src/tests.rs
@@ -18,8 +18,7 @@ use frame_support::{
 	assert_noop, assert_ok,
 	traits::{Currency, Get},
 };
-use pallet_balances::Error as BalancesError;
-use sp_runtime::{DispatchError, TokenError};
+use sp_runtime::{traits::Convert, ArithmeticError, DispatchError, TokenError};
 
 #[test]
 fn create_order_works() {
@@ -134,12 +133,12 @@ fn contribute_works() {
 		// Insufficient balance:
 		assert_noop!(
 			Orders::contribute(RuntimeOrigin::signed(CHARLIE), 0, 100_000),
-			BalancesError::<Test>::InsufficientBalance
+			ArithmeticError::Underflow
 		);
 
 		assert_eq!(Orders::contributions(0, CHARLIE), 0);
 
-		// Should be working fine
+		// Should work fine
 		assert_ok!(Orders::contribute(RuntimeOrigin::signed(CHARLIE), 0, 500));
 		System::assert_last_event(
 			Event::Contributed { order_id: 0, who: CHARLIE, amount: 500 }.into(),
@@ -153,9 +152,9 @@ fn contribute_works() {
 		assert_eq!(Orders::total_contributions(0), 600);
 
 		assert_eq!(Balances::free_balance(CHARLIE), 500);
-		assert_eq!(Balances::reserved_balance(CHARLIE), 500);
 		assert_eq!(Balances::free_balance(BOB), 900);
-		assert_eq!(Balances::reserved_balance(BOB), 100);
+		let order_account = DummyOrderToAccountId::convert(0);
+		assert_eq!(Balances::free_balance(order_account), 600);
 
 		// Additional contributions work:
 		assert_ok!(Orders::contribute(RuntimeOrigin::signed(CHARLIE), 0, 300));
@@ -199,21 +198,22 @@ fn remove_contribution_works() {
 		assert_ok!(Orders::contribute(RuntimeOrigin::signed(BOB), 0, 200));
 
 		assert_eq!(Balances::free_balance(CHARLIE), 500);
-		assert_eq!(Balances::reserved_balance(CHARLIE), 500);
 		assert_eq!(Orders::total_contributions(0), 700);
+		let order_account = DummyOrderToAccountId::convert(0);
+		assert_eq!(Balances::free_balance(order_account.clone()), 700);
 
 		// Cancel the expired order:
 		let timeslice: u64 = <Test as crate::Config>::TimeslicePeriod::get();
 		RelayBlockNumber::set(9 * timeslice);
 		assert_ok!(Orders::cancel_order(RuntimeOrigin::signed(ALICE), 0));
 
-		// Should be working fine
+		// Should work fine
 		assert_ok!(Orders::remove_contribution(RuntimeOrigin::signed(CHARLIE), 0));
 
 		// Check storage items
-		assert_eq!(Balances::reserved_balance(CHARLIE), 0);
 		assert_eq!(Balances::free_balance(CHARLIE), 1000);
 		assert_eq!(Orders::total_contributions(0), 200);
+		assert_eq!(Balances::free_balance(order_account), 200);
 
 		// Check the events
 		System::assert_last_event(

--- a/runtime/cocos/Cargo.toml
+++ b/runtime/cocos/Cargo.toml
@@ -76,6 +76,7 @@ sp-consensus-aura = { workspace = true }
 sp-core = { workspace = true }
 sp-genesis-builder = { workspace = true }
 sp-inherents = { workspace = true }
+sp-io = { workspace = true }
 sp-offchain = { workspace = true }
 sp-runtime = { workspace = true }
 sp-session = { workspace = true }
@@ -181,6 +182,7 @@ std = [
 	"sp-core/std",
 	"sp-genesis-builder/std",
 	"sp-inherents/std",
+	"sp-io/std",
 	"sp-offchain/std",
 	"sp-runtime/std",
 	"sp-session/std",


### PR DESCRIPTION
In the order processor pallet, we will have to transfer all the tokens accumulated by the order. We were reserving the contributions instead of transferring them to a separate account. This makes it inefficient to transfer the tokens to the account which sells Coretime to the order.

This PR fixes the issue by making the following changes:
- Each order has an associated account, which is generated using the `OrderToAccountId` type that is configurable within the pallet config.
- Instead of reserving tokens, these tokens are sent to the order account, ensuring they are all in one place.
- We removed the `TotalContributions` storage map, as we can keep track of this by reading the free balance of the order account.