### PR TITLE
Remove `SovereignAccountOf` from order pallet config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1288,6 +1288,7 @@ dependencies = [
  "sp-core",
  "sp-genesis-builder",
  "sp-inherents",
+ "sp-io",
  "sp-mmr-primitives",
  "sp-offchain",
  "sp-runtime",
@@ -6975,9 +6976,6 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "staging-xcm",
- "staging-xcm-builder",
- "staging-xcm-executor",
 ]
 
 [[package]]

--- a/pallets/orders/Cargo.toml
+++ b/pallets/orders/Cargo.toml
@@ -23,19 +23,15 @@ sp-io = { workspace = true, default-features = false }
 sp-core = { workspace = true, default-features = false }
 sp-runtime = { workspace = true, default-features = false }
 pallet-broker = { workspace = true, default-features = false }
-xcm-executor = { workspace = true, default-features = false }
 
 [dev-dependencies]
 serde = { workspace = true }
 pallet-balances = { workspace = true, default-features = false }
-xcm = { workspace = true, default-features = false }
-xcm-builder = { workspace = true, default-features = false }
 
 [features]
 default = ["std"]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks", 
-	"xcm-builder/runtime-benchmarks",
 ]
 std = [
 	"log/std",
@@ -50,8 +46,5 @@ std = [
 	"frame-system/std",
 	"pallet-broker/std",
 	"pallet-balances/std",
-	"xcm/std",
-	"xcm-executor/std",
-	"xcm-builder/std",
 ]
 try-runtime = ["frame-support/try-runtime"]

--- a/pallets/orders/src/lib.rs
+++ b/pallets/orders/src/lib.rs
@@ -22,7 +22,6 @@ use sp_runtime::{
 	traits::{BlockNumberProvider, Convert},
 	SaturatedConversion,
 };
-use xcm_executor::traits::ConvertLocation;
 
 #[cfg(test)]
 mod mock;
@@ -64,9 +63,6 @@ pub mod pallet {
 
 		/// Currency used for purchasing coretime.
 		type Currency: Mutate<Self::AccountId> + ReservableCurrency<Self::AccountId>;
-
-		/// How to get an `AccountId` value from a `Location`.
-		type SovereignAccountOf: ConvertLocation<Self::AccountId>;
 
 		/// Type responsible for dealing with order creation fees.
 		type OrderCreationFeeHandler: FeeHandler<Self::AccountId, BalanceOf<Self>>;

--- a/pallets/orders/src/mock.rs
+++ b/pallets/orders/src/mock.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with RegionX.  If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{FeeHandler, OrderId, ParaId};
+use crate::{FeeHandler, OrderId};
 use frame_support::{
 	pallet_prelude::*,
 	parameter_types,
@@ -24,11 +24,6 @@ use sp_io::hashing::blake2_256;
 use sp_runtime::{
 	traits::{BlakeTwo256, BlockNumberProvider, Convert, IdentityLookup},
 	AccountId32, BuildStorage,
-};
-use xcm::opaque::lts::NetworkId;
-
-use xcm_builder::{
-	AccountId32Aliases, ChildParachainConvertsVia, DescribeAllTerminal, HashedDescription,
 };
 
 type AccountId = AccountId32;
@@ -47,16 +42,6 @@ frame_support::construct_runtime!(
 		Balances: pallet_balances,
 		Orders: crate::{Pallet, Call, Storage, Event<T>},
 	}
-);
-
-parameter_types! {
-	pub const AnyNetwork: Option<NetworkId> = None;
-}
-
-pub type SovereignAccountOf = (
-	ChildParachainConvertsVia<ParaId, AccountId>,
-	AccountId32Aliases<AnyNetwork, AccountId>,
-	HashedDescription<AccountId, DescribeAllTerminal>,
 );
 
 parameter_types! {
@@ -138,7 +123,6 @@ impl Convert<OrderId, AccountId> for OrderToAccountId {
 impl crate::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type Currency = Balances;
-	type SovereignAccountOf = SovereignAccountOf;
 	type OrderCreationCost = ConstU64<100>;
 	type MinimumContribution = ConstU64<50>;
 	type RCBlockNumberProvider = RelayBlockNumberProvider;

--- a/runtime/cocos/src/lib.rs
+++ b/runtime/cocos/src/lib.rs
@@ -38,7 +38,6 @@ mod ismp;
 
 use impls::*;
 
-use crate::xcm_config::LocationToAccountId;
 use codec::Encode;
 use cumulus_pallet_parachain_system::{
 	RelayChainState, RelayNumberMonotonicallyIncreases, RelaychainDataProvider,
@@ -777,7 +776,6 @@ impl Convert<OrderId, AccountId> for OrderToAccountId {
 impl pallet_orders::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Currency = RelaychainCurrency;
-	type SovereignAccountOf = LocationToAccountId;
 	type OrderCreationCost = OrderCreationCost;
 	type MinimumContribution = MinimumContribution;
 	type OrderCreationFeeHandler = OrderCreationFeeHandler;


### PR DESCRIPTION
We initially wanted to use it and then realized there is no need for it, however we forgot to remove `SovereignAccountOf` from the pallet config.

This PR fixes that.