### PR TITLE
Use `u64` for accounts in order pallet tests

### DIFF
--- a/pallets/orders/src/mock.rs
+++ b/pallets/orders/src/mock.rs
@@ -20,19 +20,15 @@ use frame_support::{
 	traits::{fungible::Mutate, tokens::Preservation, Everything},
 };
 use sp_core::{ConstU64, H256};
-use sp_io::hashing::blake2_256;
 use sp_runtime::{
 	traits::{BlakeTwo256, BlockNumberProvider, Convert, IdentityLookup},
-	AccountId32, BuildStorage,
+	BuildStorage,
 };
 
-type AccountId = AccountId32;
+type AccountId = u64;
 type Block = frame_system::mocking::MockBlock<Test>;
 
-pub const ALICE: AccountId = AccountId::new([0u8; 32]);
-pub const BOB: AccountId = AccountId::new([1u8; 32]);
-pub const CHARLIE: AccountId = AccountId::new([2u8; 32]);
-pub const TREASURY: AccountId = AccountId::new([3u8; 32]);
+pub const TREASURY: AccountId = 42;
 
 // Configure a mock runtime to test the pallet.
 frame_support::construct_runtime!(
@@ -116,7 +112,7 @@ impl BlockNumberProvider for RelayBlockNumberProvider {
 pub struct OrderToAccountId;
 impl Convert<OrderId, AccountId> for OrderToAccountId {
 	fn convert(order: OrderId) -> AccountId {
-		("order", order).using_encoded(blake2_256).into()
+		1000u64 + order as u64
 	}
 }
 
@@ -133,7 +129,7 @@ impl crate::Config for Test {
 }
 
 // Build genesis storage according to the mock runtime.
-pub fn new_test_ext(endowed_accounts: Vec<(AccountId32, u64)>) -> sp_io::TestExternalities {
+pub fn new_test_ext(endowed_accounts: Vec<(AccountId, u64)>) -> sp_io::TestExternalities {
 	let mut t = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
 	pallet_balances::GenesisConfig::<Test> { balances: endowed_accounts }
 		.assimilate_storage(&mut t)

--- a/pallets/orders/src/tests.rs
+++ b/pallets/orders/src/tests.rs
@@ -22,8 +22,8 @@ use sp_runtime::{traits::Convert, ArithmeticError, DispatchError, TokenError};
 
 #[test]
 fn create_order_works() {
-	new_test_ext(vec![(BOB, 1000), (CHARLIE, 1000)]).execute_with(|| {
-		let creator = ALICE;
+	new_test_ext(vec![(2, 1000), (3, 1000)]).execute_with(|| {
+		let creator = 1;
 		let para_id: ParaId = 2000.into();
 		let requirements = Requirements {
 			begin: 0,
@@ -52,7 +52,7 @@ fn create_order_works() {
 
 		// Check storage items
 		assert_eq!(Orders::next_order_id(), 1);
-		assert_eq!(Orders::orders(0), Some(Order { para_id, creator: ALICE, requirements }));
+		assert_eq!(Orders::orders(0), Some(Order { para_id, creator: 1, requirements }));
 		assert!(Orders::orders(1).is_none());
 
 		// Balance should be reduced due to fee payment:
@@ -67,8 +67,8 @@ fn create_order_works() {
 
 #[test]
 fn anyone_can_cancel_expired_order() {
-	new_test_ext(vec![(ALICE, 1000), (BOB, 1000), (CHARLIE, 1000)]).execute_with(|| {
-		let creator = ALICE;
+	new_test_ext(vec![(1, 1000), (2, 1000), (3, 1000)]).execute_with(|| {
+		let creator = 1;
 		let para_id: ParaId = 2000.into();
 		let timeslice: u64 = <Test as crate::Config>::TimeslicePeriod::get();
 		let requirements = Requirements {
@@ -91,132 +91,127 @@ fn anyone_can_cancel_expired_order() {
 		));
 
 		// Cannot cancel a non-expired order:
-		assert_noop!(
-			Orders::cancel_order(RuntimeOrigin::signed(ALICE), 0),
-			Error::<Test>::NotAllowed
-		);
+		assert_noop!(Orders::cancel_order(RuntimeOrigin::signed(1), 0), Error::<Test>::NotAllowed);
 
 		// Anyone can cancel expired order:
 		RelayBlockNumber::set(9 * timeslice);
-		assert_ok!(Orders::cancel_order(RuntimeOrigin::signed(BOB), 0));
+		assert_ok!(Orders::cancel_order(RuntimeOrigin::signed(2), 0));
 
 		// Check storage items
 		assert!(Orders::orders(0).is_none());
 
 		// Check events
-		System::assert_last_event(Event::OrderRemoved { order_id: 0, by: BOB }.into());
+		System::assert_last_event(Event::OrderRemoved { order_id: 0, by: 2 }.into());
 	});
 }
 
 #[test]
 fn contribute_works() {
-	new_test_ext(vec![(ALICE, 1000), (BOB, 1000), (CHARLIE, 1000)]).execute_with(|| {
+	new_test_ext(vec![(1, 1000), (2, 1000), (3, 1000)]).execute_with(|| {
 		// Create an order
 		assert_ok!(Orders::create_order(
-			RuntimeOrigin::signed(ALICE),
+			RuntimeOrigin::signed(1),
 			2000.into(),
 			Requirements { begin: 0, end: 8, core_occupancy: 28800 }
 		));
 
 		// Invalid order id
 		assert_noop!(
-			Orders::contribute(RuntimeOrigin::signed(ALICE), 2, 1_000),
+			Orders::contribute(RuntimeOrigin::signed(1), 2, 1_000),
 			Error::<Test>::InvalidOrderId
 		);
 
 		// Contribution amount is too small
 		assert_noop!(
-			Orders::contribute(RuntimeOrigin::signed(CHARLIE), 0, 0),
+			Orders::contribute(RuntimeOrigin::signed(3), 0, 0),
 			Error::<Test>::InvalidAmount,
 		);
 
 		// Insufficient balance:
 		assert_noop!(
-			Orders::contribute(RuntimeOrigin::signed(CHARLIE), 0, 100_000),
+			Orders::contribute(RuntimeOrigin::signed(3), 0, 100_000),
 			ArithmeticError::Underflow
 		);
 
-		assert_eq!(Orders::contributions(0, CHARLIE), 0);
+		assert_eq!(Orders::contributions(0, 3), 0);
 
 		// Should work fine
-		assert_ok!(Orders::contribute(RuntimeOrigin::signed(CHARLIE), 0, 500));
-		System::assert_last_event(
-			Event::Contributed { order_id: 0, who: CHARLIE, amount: 500 }.into(),
-		);
+		assert_ok!(Orders::contribute(RuntimeOrigin::signed(3), 0, 500));
+		System::assert_last_event(Event::Contributed { order_id: 0, who: 3, amount: 500 }.into());
 
-		assert_ok!(Orders::contribute(RuntimeOrigin::signed(BOB), 0, 100));
-		System::assert_last_event(Event::Contributed { order_id: 0, who: BOB, amount: 100 }.into());
+		assert_ok!(Orders::contribute(RuntimeOrigin::signed(2), 0, 100));
+		System::assert_last_event(Event::Contributed { order_id: 0, who: 2, amount: 100 }.into());
 		// Check storage items
-		assert_eq!(Orders::contributions(0, CHARLIE), 500);
-		assert_eq!(Orders::contributions(0, BOB), 100);
+		assert_eq!(Orders::contributions(0, 3), 500);
+		assert_eq!(Orders::contributions(0, 2), 100);
 
-		assert_eq!(Balances::free_balance(CHARLIE), 500);
-		assert_eq!(Balances::free_balance(BOB), 900);
+		assert_eq!(Balances::free_balance(3), 500);
+		assert_eq!(Balances::free_balance(2), 900);
 		let order_account = OrderToAccountId::convert(0);
 		assert_eq!(Balances::free_balance(order_account), 600);
 
 		// Additional contributions work:
-		assert_ok!(Orders::contribute(RuntimeOrigin::signed(CHARLIE), 0, 300));
-		assert_eq!(Orders::contributions(0, CHARLIE), 800);
-		assert_eq!(Orders::contributions(0, BOB), 100);
+		assert_ok!(Orders::contribute(RuntimeOrigin::signed(3), 0, 300));
+		assert_eq!(Orders::contributions(0, 3), 800);
+		assert_eq!(Orders::contributions(0, 2), 100);
 
 		// Cannot contribute to an expired order
 		let timeslice: u64 = <Test as crate::Config>::TimeslicePeriod::get();
 		RelayBlockNumber::set(timeslice * 9);
 
 		assert_noop!(
-			Orders::contribute(RuntimeOrigin::signed(ALICE), 0, 100),
+			Orders::contribute(RuntimeOrigin::signed(1), 0, 100),
 			Error::<Test>::OrderExpired
 		);
 
-		assert_eq!(Orders::contributions(0, CHARLIE), 800);
-		assert_eq!(Orders::contributions(0, BOB), 100);
+		assert_eq!(Orders::contributions(0, 3), 800);
+		assert_eq!(Orders::contributions(0, 2), 100);
 	});
 }
 
 #[test]
 fn remove_contribution_works() {
-	new_test_ext(vec![(ALICE, 1000), (BOB, 1000), (CHARLIE, 1000)]).execute_with(|| {
+	new_test_ext(vec![(1, 1000), (2, 1000), (3, 1000)]).execute_with(|| {
 		// Create an order
 		assert_ok!(Orders::create_order(
-			RuntimeOrigin::signed(ALICE),
+			RuntimeOrigin::signed(1),
 			2000.into(),
 			Requirements { begin: 0, end: 8, core_occupancy: 28800 }
 		));
 
 		// Order is not cancelled
 		assert_noop!(
-			Orders::remove_contribution(RuntimeOrigin::signed(CHARLIE), 0),
+			Orders::remove_contribution(RuntimeOrigin::signed(3), 0),
 			Error::<Test>::OrderNotCancelled
 		);
 
 		// Contribute to the order
-		assert_ok!(Orders::contribute(RuntimeOrigin::signed(CHARLIE), 0, 500));
-		assert_ok!(Orders::contribute(RuntimeOrigin::signed(BOB), 0, 200));
+		assert_ok!(Orders::contribute(RuntimeOrigin::signed(3), 0, 500));
+		assert_ok!(Orders::contribute(RuntimeOrigin::signed(2), 0, 200));
 
-		assert_eq!(Balances::free_balance(CHARLIE), 500);
+		assert_eq!(Balances::free_balance(3), 500);
 		let order_account = OrderToAccountId::convert(0);
 		assert_eq!(Balances::free_balance(order_account.clone()), 700);
 
 		// Cancel the expired order:
 		let timeslice: u64 = <Test as crate::Config>::TimeslicePeriod::get();
 		RelayBlockNumber::set(9 * timeslice);
-		assert_ok!(Orders::cancel_order(RuntimeOrigin::signed(ALICE), 0));
+		assert_ok!(Orders::cancel_order(RuntimeOrigin::signed(1), 0));
 
 		// Should work fine
-		assert_ok!(Orders::remove_contribution(RuntimeOrigin::signed(CHARLIE), 0));
+		assert_ok!(Orders::remove_contribution(RuntimeOrigin::signed(3), 0));
 
 		// Check storage items
-		assert_eq!(Balances::free_balance(CHARLIE), 1000);
+		assert_eq!(Balances::free_balance(3), 1000);
 		assert_eq!(Balances::free_balance(order_account), 200);
 
 		// Check the events
 		System::assert_last_event(
-			Event::ContributionRemoved { order_id: 0, who: CHARLIE, amount: 500 }.into(),
+			Event::ContributionRemoved { order_id: 0, who: 3, amount: 500 }.into(),
 		);
 
 		assert_noop!(
-			Orders::remove_contribution(RuntimeOrigin::signed(CHARLIE), 0),
+			Orders::remove_contribution(RuntimeOrigin::signed(3), 0),
 			Error::<Test>::NoContribution
 		);
 	});


### PR DESCRIPTION
There is no need to use `AccountId32` in the tests. 