### PR TITLE
Test runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,20 +24,20 @@
     - block production
 
         ```
-        zombienet-linux -p native test ./zombienet_tests/general/block-production.zndsl
+        npm run test -- ./zombienet_tests/general/block-production.zndsl
         ```
 
     - fee payment
         - fee payment in native tokens
 
             ```
-            zombienet-linux -p native test ./zombienet_tests/fee-payment/native-fee-payment.zndsl
+            npm run test -- ./zombienet_tests/fee-payment/native-fee-payment.zndsl
             ```
 
         - fee payment in custom assets
 
             ```
-            zombienet-linux -p native test ./zombienet_tests/fee-payment/custom-fee-payment.zndsl
+            npm run test -- ./zombienet_tests/fee-payment/custom-fee-payment.zndsl
             ```
 
     - governance
@@ -45,13 +45,13 @@
         - delegated governance(relay chain token holders)
 
             ```
-            zombienet-linux -p native test ./zombienet_tests/governance/delegated-governance.zndsl
+            npm run test -- ./zombienet_tests/governance/delegated-governance.zndsl
             ```
 
         - native governance(RegionX token holders)
 
             ```
-            zombienet-linux -p native test ./zombienet_tests/governance/native-governance.zndsl
+            npm run test -- ./zombienet_tests/governance/native-governance.zndsl
             ```
     
     - cross-chain transfer
@@ -59,11 +59,11 @@
         - transfer assets
         
             ```
-            zombienet-linux -p native test ./zombienet_tests/xc-transfer/asset-transfer.zndsl
+            npm run test -- ./zombienet_tests/xc-transfer/asset-transfer.zndsl
             ```
 
         - transfer regions
 
             ```
-            zombienet-linux -p native test ./zombienet_tests/xc-transfer/region-transfer.zndsl
+            npm run test -- ./zombienet_tests/xc-transfer/region-transfer.zndsl
             ```

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "npx tsc > /dev/null",
     "lint": "eslint e2e_tests --fix",
-    "format": "npx prettier --write './e2e_tests/**/*.ts'"
+    "format": "npx prettier --write './e2e_tests/**/*.ts'",
+    "test": "chmod +x ./scripts/test-runner.sh && ./scripts/test-runner.sh"
   },
   "keywords": [],
   "author": "",

--- a/scripts/test-runner.sh
+++ b/scripts/test-runner.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [ ! -e "regionx-node" ]; then 
+    echo "regionx-node binary not found"
+    echo "run: cargo build --release --features fast-runtime && cp target/release/regionx-node ."
+    exit 1
+fi
+
+if [ ! -e "polkadot" ] || [ ! -e "polkadot-parachain" ]; then
+    zombienet-linux setup polkadot polkadot-parachain
+fi
+
+export PATH=$PWD:$PATH
+
+npm run build
+
+zombienet-linux -p native test $1


### PR DESCRIPTION
It is very easy to forget to run `npm run build` after changing the test files. Also, it is quite annoying to have to do this every time.

With this PR, we introduce a test runner that will take care of everything, so we just have to execute a single command.