### PR TITLE
Missing Events

### DIFF
--- a/pallets/regions/src/lib.rs
+++ b/pallets/regions/src/lib.rs
@@ -182,6 +182,8 @@ pub mod pallet {
 			/// the account that dropped the region
 			who: T::AccountId,
 		},
+		/// Request for a region record timed out.
+		RequestTimedOut { region_id: RegionId },
 	}
 
 	#[pallet::error]
@@ -464,6 +466,7 @@ impl<T: Config> IsmpModule for IsmpModuleCallback<T> {
 				region.record = Record::Unavailable;
 				Regions::<T>::insert(region_id, region);
 
+				crate::Pallet::<T>::deposit_event(Event::RequestTimedOut { region_id });
 				Ok(())
 			}),
 			Timeout::Request(Request::Post(_)) => Ok(()),

--- a/pallets/regions/src/lib.rs
+++ b/pallets/regions/src/lib.rs
@@ -418,6 +418,7 @@ impl<T: Config> Default for IsmpModuleCallback<T> {
 	}
 }
 
+use frame_support::ensure;
 impl<T: Config> IsmpModule for IsmpModuleCallback<T> {
 	fn on_accept(&self, _request: Post) -> Result<(), IsmpError> {
 		Err(IsmpCustomError::NotSupported.into())

--- a/pallets/regions/src/lib.rs
+++ b/pallets/regions/src/lib.rs
@@ -418,7 +418,6 @@ impl<T: Config> Default for IsmpModuleCallback<T> {
 	}
 }
 
-use frame_support::ensure;
 impl<T: Config> IsmpModule for IsmpModuleCallback<T> {
 	fn on_accept(&self, _request: Post) -> Result<(), IsmpError> {
 		Err(IsmpCustomError::NotSupported.into())

--- a/pallets/regions/src/lib.rs
+++ b/pallets/regions/src/lib.rs
@@ -157,6 +157,8 @@ pub mod pallet {
 		RegionMinted {
 			/// id of the minted region
 			region_id: RegionId,
+			/// address of the minter
+			by: T::AccountId,
 		},
 		/// A region was burnt.
 		RegionBurnt {

--- a/pallets/regions/src/nonfungible_impls.rs
+++ b/pallets/regions/src/nonfungible_impls.rs
@@ -70,7 +70,7 @@ impl<T: Config> Mutate<T::AccountId> for Pallet<T> {
 			Region { owner: who.clone(), locked: false, record: Record::Unavailable },
 		);
 
-		Pallet::<T>::deposit_event(Event::RegionMinted { region_id });
+		Pallet::<T>::deposit_event(Event::RegionMinted { region_id, by: who.clone() });
 
 		log::info!(
 			target: LOG_TARGET,

--- a/pallets/regions/src/tests.rs
+++ b/pallets/regions/src/tests.rs
@@ -41,7 +41,7 @@ fn nonfungibles_implementation_works() {
 
 		assert!(Regions::regions(&region_id).is_none());
 		assert_ok!(Regions::mint_into(&region_id.into(), &2));
-		System::assert_last_event(Event::RegionMinted { region_id }.into());
+		System::assert_last_event(Event::RegionMinted { region_id, by: 2u32.into() }.into());
 		assert_eq!(
 			Regions::regions(&region_id).unwrap(),
 			Region { owner: 2, locked: false, record: Record::Unavailable }

--- a/pallets/regions/src/tests.rs
+++ b/pallets/regions/src/tests.rs
@@ -18,7 +18,7 @@ use crate::{
 	Error, Event, IsmpCustomError, IsmpModuleCallback, Record, Region,
 };
 use frame_support::{
-	assert_noop, assert_ok,
+	assert_err, assert_noop, assert_ok,
 	pallet_prelude::*,
 	traits::nonfungible::{Inspect, Mutate, Transfer as NonFungibleTransfer},
 };
@@ -287,7 +287,7 @@ fn on_timeout_works() {
 		// failed to decode region_id
 		let mut invalid_get_req = get.clone();
 		invalid_get_req.keys.push(vec![0u8; 15]);
-		assert_noop!(
+		assert_err!(
 			module.on_timeout(Timeout::Request(Request::Get(invalid_get_req.clone()))),
 			IsmpCustomError::KeyDecodeFailed
 		);


### PR DESCRIPTION
added the following missing events to `pallet-regions`
- one additional field for `RegionMinted` event - `by` : address of the minter
- `IsmpReqTimeout` - to signal that the ISMP get request is timed out.