### PR TITLE
Orders runtime api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6989,6 +6989,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
+ "sp-api",
  "sp-core",
  "sp-io",
  "sp-runtime",

--- a/pallets/orders/Cargo.toml
+++ b/pallets/orders/Cargo.toml
@@ -19,6 +19,7 @@ cumulus-primitives-core = { workspace = true, default-features = false }
 frame-benchmarking = { workspace = true, default-features = false, optional = true }
 frame-support = { workspace = true, default-features = false }
 frame-system = { workspace = true, default-features = false }
+sp-api = { workspace = true, default-features = false }
 sp-io = { workspace = true, default-features = false }
 sp-core = { workspace = true, default-features = false }
 sp-runtime = { workspace = true, default-features = false }
@@ -41,6 +42,7 @@ std = [
 	"codec/std",
 	"cumulus-primitives-core/std",
 	"scale-info/std",
+	"sp-api/std",
 	"sp-io/std",
 	"sp-core/std",
 	"sp-runtime/std",

--- a/pallets/orders/src/lib.rs
+++ b/pallets/orders/src/lib.rs
@@ -39,6 +39,8 @@ pub use crate::types::*;
 pub mod weights;
 pub use weights::WeightInfo;
 
+pub mod runtime_api;
+
 pub type BalanceOf<T> =
 	<<T as crate::Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
 

--- a/pallets/orders/src/runtime_api.rs
+++ b/pallets/orders/src/runtime_api.rs
@@ -1,0 +1,27 @@
+// This file is part of RegionX.
+//
+// RegionX is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// RegionX is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with RegionX.  If not, see <https://www.gnu.org/licenses/>.
+
+use codec::Codec;
+use order_primitives::OrderId;
+
+sp_api::decl_runtime_apis! {
+	pub trait OrdersApi<AccountId>
+	where
+		AccountId: Codec
+	{
+		/// Returns the account of an order.
+		fn order_account(order_id: OrderId) -> AccountId;
+	}
+}

--- a/runtime/cocos/src/lib.rs
+++ b/runtime/cocos/src/lib.rs
@@ -1126,6 +1126,12 @@ impl_runtime_apis! {
 		}
 	}
 
+	impl pallet_orders::runtime_api::OrdersApi<Block, AccountId> for Runtime {
+		fn order_account(order_id: OrderId) -> AccountId {
+			<Runtime as pallet_orders::Config>::OrderToAccountId::convert(order_id)
+		}
+	}
+
 	#[cfg(feature = "try-runtime")]
 	impl frame_try_runtime::TryRuntime<Block> for Runtime {
 		fn on_runtime_upgrade(checks: frame_try_runtime::UpgradeCheckSelect) -> (Weight, Weight) {


### PR DESCRIPTION
Instead of implementing the logic for converting an `OrderId` to an account, we expose this as a runtime api.