### PR TITLE
Fix processor-pallet `LOG_TARGET`

### DIFF
--- a/pallets/processor/src/lib.rs
+++ b/pallets/processor/src/lib.rs
@@ -41,7 +41,7 @@ pub mod assigner;
 mod weights;
 pub use weights::WeightInfo;
 
-const LOG_TARGET: &str = "runtime::order-creator";
+const LOG_TARGET: &str = "runtime::processor";
 
 pub type BalanceOf<T> =
 	<<T as crate::Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;


### PR DESCRIPTION
When initializing the module, the code was copied from the order-creator pallet from https://github.com/RegionX-Labs/RegionX-Pallets; however, the LOG_TARGET wasn't updated.

This PR fixes that.